### PR TITLE
Added onRender callback functionality

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -543,6 +543,13 @@
             <p>At the moment works only with option <strong>disallowLockDaysInRange</strong>.</p>
           </div>
 
+          <div>onRender</div>
+          <div class="option-default">null</div>
+          <div class="option-description">
+            <p>Trigger after the render of the picker.</p>
+            <p>Example: <code>onRender: function() { console.log('rendered'); }</code></p>
+          </div>
+
           <div>onChangeMonth</div>
           <div class="option-default">null</div>
           <div class="option-description">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "litepicker",
-  "version": "1.0.16",
+  "version": "1.0.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -67,6 +67,7 @@ export class Calendar {
     onHide: null,
     onSelect: null,
     onError: null,
+    onRender: null,
     onChangeMonth: null,
     onChangeYear: null,
   };
@@ -121,6 +122,10 @@ export class Calendar {
 
     if (this.options.showTooltip) {
       this.picker.appendChild(this.renderTooltip());
+    }
+
+    if (typeof this.options.onRender === 'function') {
+      this.options.onRender.call(this);
     }
   }
 


### PR DESCRIPTION
Added a callback triggered after the calendar has rendered.
This is usefull when you want to add custom html to the picker. 
See issue https://github.com/wakirin/Litepicker/issues/35 