### PR TITLE
Add toISOString to DateTime

### DIFF
--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -129,6 +129,10 @@ export class DateTime {
     this.lang = lang;
   }
 
+  public toISOString() {
+    return this.dateInstance.toISOString();
+  }
+
   public toLocaleString(arg0, arg1) {
     return this.dateInstance.toLocaleString(arg0, arg1);
   }

--- a/tests/datetime.test.ts
+++ b/tests/datetime.test.ts
@@ -206,3 +206,9 @@ test('DateTime format', () => {
   expect(dt.format('YYYY-MM-DD') === '2019-11-23').toBe(true);
   expect(dt.format('DD MMM, YYYY') === '23 Nov, 2019').toBe(true);
 });
+
+test('DateTime toISOString', () => {
+  const dt = new DateTime(date);
+
+  expect(dt.toISOString().substr(0, 10)).toBe('2019-11-23');
+});


### PR DESCRIPTION
The `DateTime` instance is missing a pass through method to the `dateInstance` for `toISOString`.