### PR TITLE
Code changes that enable allowRepick when inlineMode is active

### DIFF
--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -14,8 +14,7 @@ export class Litepicker extends Calendar {
 
     this.options = { ...this.options, ...options };
 
-    if ((this.options.allowRepick && this.options.inlineMode)
-      || !this.options.elementEnd) {
+    if (!this.options.elementEnd) {
       this.options.allowRepick = false;
     }
 
@@ -534,7 +533,7 @@ export class Litepicker extends Calendar {
       if (this.shouldAllowRepick()) {
         if (this.triggerElement === this.options.element) {
           this.datePicked[0] = this.options.endDate.clone();
-        } else {
+        } else if (this.triggerElement === this.options.elementEnd) {
           this.datePicked[0] = this.options.startDate.clone();
         }
       }

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -31,6 +31,9 @@ declare module './litepicker' {
 }
 
 Litepicker.prototype.show = function (el = null) {
+  const element = el ? el : this.options.element;
+  this.triggerElement = element;
+
   if (this.options.inlineMode) {
     this.picker.style.position = 'static';
     this.picker.style.display = 'inline-block';
@@ -40,9 +43,6 @@ Litepicker.prototype.show = function (el = null) {
     this.picker.style.right = null;
     return;
   }
-
-  const element = el ? el : this.options.element;
-  this.triggerElement = element;
 
   if (this.options.scrollToDate) {
     if (this.options.startDate && (!el || el === this.options.element)) {
@@ -240,6 +240,9 @@ Litepicker.prototype.setEndDate = function (date) {
 };
 
 Litepicker.prototype.setDateRange = function (date1, date2) {
+  // stop repicking by resetting the trigger element
+  this.triggerElement = undefined;
+
   this.setStartDate(date1);
   this.setEndDate(date2);
 

--- a/tests/index-daterange.html
+++ b/tests/index-daterange.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, minimum-scale=1.0">
+  <title>Litepicker - Date range picker - lightweight, no dependencies</title>
+</head>
+
+<body>
+  <input id="datepicker">
+  <input id="datepickerend">
+  <button id="repick1">Change arrival</button>
+  <button id="repick2">Change departure</button>
+  <!-- Polyfill needed for CSS properties support in IE11 -->
+  <script>window.MSInputMethodContext && document.documentMode && document.write('<script src="./ie11CustomProperties.js"><\x2fscript>');</script>
+  <script src="../dist/js/main.js"></script>
+  <script>
+    var picker = new Litepicker({
+      element: document.getElementById('datepicker'),
+      elementEnd: document.getElementById('datepickerend'),
+      onSelect: function(a,b) {
+        console.log(a,b);
+      },
+      inlineMode:true,
+      allowRepick:true,
+      singleMode:false,
+      numberOfMonths: 2,
+    numberOfColumns: 2
+    });
+    document.getElementById("repick1").
+    addEventListener("click", function() {
+      picker.show(document.getElementById('datepicker'));
+    });
+    document.getElementById("repick2").
+    addEventListener("click", function() {
+      picker.show(document.getElementById('datepickerend'));
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
These code changes enable allowRepick mode when Litepicker runs in inlineMode. Further, I added another index*.html file under `tests/` folder that demonstrates Litepicker used for date range picking, including allowRepick. Enabling allowRepick in inlineMode is an interesting feature when Litepicker is an always visible part of a complex UI.