### PR TITLE
On day hover event

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -588,6 +588,17 @@
             <p>idx is showing which calendar has change when option <strong>splitView</strong> is enabled.</p>
             <p>idx starts from 0.</p>
           </div>
+
+          <div>onDayHover</div>
+          <div class="option-default">null</div>
+          <div class="option-description">
+            <p>Trigger when user hovers or clicks a day item.</p>
+            <p>Example: 
+              <code>onDayHover: function(date, attributes) { console.log(date, attributes); }</code>
+            </p>
+            <p><code>date</code> is the date object of the currently hovered day item.</p>
+            <p><code>attributes</code> is a string array with the day item's css classes (e.g. <strong>is-start-date</strong>, <strong>is-locked</strong>, <strong>is-booked</strong>, etc.).</p>
+          </div>
         </div>
 
         <hr>

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -7,6 +7,7 @@ export class Calendar {
     element: null,
     elementEnd: null,
     parentEl: null,
+    // tslint:disable-next-line: object-literal-sort-keys
     firstDay: 1,
     format: 'YYYY-MM-DD',
     lang: 'en-US',
@@ -48,6 +49,7 @@ export class Calendar {
 
     dropdowns: {
       minYear: 1990,
+      // tslint:disable-next-line: object-literal-sort-keys
       maxYear: null,
       months: false,
       years: false,
@@ -222,7 +224,8 @@ export class Calendar {
         option.text = x;
         option.disabled = (this.options.minDate
           && optionYear.isBefore(new DateTime(this.options.minDate), 'year'))
-          || (this.options.maxDate && optionYear.isAfter(new DateTime(this.options.maxDate), 'year'));
+          || (this.options.maxDate
+              && optionYear.isAfter(new DateTime(this.options.maxDate), 'year'));
         option.selected = date.getFullYear() === x;
 
         selectYears.appendChild(option);

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -77,6 +77,7 @@ export class Calendar {
     onRender: null,
     onChangeMonth: null,
     onChangeYear: null,
+    onDayHover: null,
 
     resetBtnCallback: null,
   };

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -1,12 +1,14 @@
 export class DateTime {
 
-  public static parseDateTime(date, format = 'YYYY-MM-DD', lang = 'en-US'): Date {
+  public static parseDateTime(date: Date|DateTime|string,
+                              format: string = 'YYYY-MM-DD',
+                              lang: string = 'en-US'): Date {
     if (!date) return new Date(NaN);
 
-    if (date instanceof Date) return DateTime.getDateZeroTime(new Date(date));
+    if (date instanceof Date) return new Date(date);
     if (date instanceof DateTime) return date.clone().getDateInstance();
 
-    if (/^\d{10,}$/.test(date)) return DateTime.getDateZeroTime(new Date(Number(date)));
+    if (/^\d{10,}$/.test(date as string)) return DateTime.getDateZeroTime(new Date(Number(date)));
 
     if (typeof date === 'string') {
       const match = format.match(/\[([^\]]+)]|Y{2,4}|M{1,4}|D{1,2}|d{1,4}/g);
@@ -97,27 +99,28 @@ export class DateTime {
     return DateTime.getDateZeroTime(new Date(date));
   }
 
-  public static convertArray(array, format) {
+  public static convertArray(array: Array<Date| Date[]|string|string[]>,
+                             format: string): Array<DateTime | DateTime[]> {
     return array
       .map((d) => {
         if (d instanceof Array) {
-          return d.map(d1 => new DateTime(d1, format));
+          return (d as Array<Date|string>).map(d1 => new DateTime(d1, format));
         }
         return new DateTime(d, format);
       });
   }
 
-  public static getDateZeroTime(date): Date {
+  public static getDateZeroTime(date: Date): Date {
     return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
   }
 
   private static readonly MONTH_JS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 
-  protected lang;
+  protected lang: string;
 
   private dateInstance: Date;
 
-  constructor(date = null, format: string = null, lang = 'en-US') {
+  constructor(date: Date|DateTime|string = null, format: string = null, lang: string = 'en-US') {
     if (format) {
       this.dateInstance = (DateTime.parseDateTime(date, format, lang));
     } else if (date) {
@@ -133,55 +136,55 @@ export class DateTime {
     return this.dateInstance;
   }
 
-  public toLocaleString(arg0, arg1) {
+  public toLocaleString(arg0: string, arg1: Intl.DateTimeFormatOptions): string {
     return this.dateInstance.toLocaleString(arg0, arg1);
   }
 
-  public toDateString() {
+  public toDateString(): string {
     return this.dateInstance.toDateString();
   }
 
-  public getSeconds() {
+  public getSeconds(): number {
     return this.dateInstance.getSeconds();
   }
 
-  public getDay() {
+  public getDay(): number {
     return this.dateInstance.getDay();
   }
 
-  public getTime() {
+  public getTime(): number {
     return this.dateInstance.getTime();
   }
 
-  public getDate() {
+  public getDate(): number {
     return this.dateInstance.getDate();
   }
 
-  public getMonth() {
+  public getMonth(): number {
     return this.dateInstance.getMonth();
   }
 
-  public getFullYear() {
+  public getFullYear(): number {
     return this.dateInstance.getFullYear();
   }
 
-  public setMonth(arg) {
+  public setMonth(arg: number): number {
     return this.dateInstance.setMonth(arg);
   }
 
-  public setSeconds(arg) {
+  public setSeconds(arg: number): number {
     return this.dateInstance.setSeconds(arg);
   }
 
-  public setDate(arg) {
+  public setDate(arg: number): number {
     return this.dateInstance.setDate(arg);
   }
 
-  public setFullYear(arg) {
+  public setFullYear(arg: number): number {
     return this.dateInstance.setFullYear(arg);
   }
 
-  public getWeek(firstDay) {
+  public getWeek(firstDay: number): number {
     const target = new Date(this.timestamp());
     const dayNr = (this.getDay() + (7 - firstDay)) % 7;
     target.setDate(target.getDate() - dayNr);
@@ -194,10 +197,10 @@ export class DateTime {
   }
 
   public clone(): DateTime {
-    return new DateTime(this.getTime());
+    return new DateTime(this.getDateInstance());
   }
 
-  public isBetween(date1, date2, inclusivity = '()') {
+  public isBetween(date1: DateTime, date2: DateTime, inclusivity = '()'): boolean {
 
     switch (inclusivity) {
       default:
@@ -215,7 +218,7 @@ export class DateTime {
     }
   }
 
-  public isBefore(date, unit = 'seconds') {
+  public isBefore(date: DateTime, unit = 'seconds'): boolean {
     switch (unit) {
       case 'second':
       case 'seconds':
@@ -239,7 +242,7 @@ export class DateTime {
     throw new Error('isBefore: Invalid unit!');
   }
 
-  public isSameOrBefore(date, unit = 'seconds') {
+  public isSameOrBefore(date: DateTime, unit = 'seconds'): boolean {
     switch (unit) {
       case 'second':
       case 'seconds':
@@ -259,7 +262,7 @@ export class DateTime {
     throw new Error('isSameOrBefore: Invalid unit!');
   }
 
-  public isAfter(date, unit = 'seconds') {
+  public isAfter(date: DateTime, unit = 'seconds'): boolean {
     switch (unit) {
       case 'second':
       case 'seconds':
@@ -283,7 +286,7 @@ export class DateTime {
     throw new Error('isAfter: Invalid unit!');
   }
 
-  public isSameOrAfter(date, unit = 'seconds') {
+  public isSameOrAfter(date: DateTime, unit = 'seconds'): boolean {
     switch (unit) {
       case 'second':
       case 'seconds':
@@ -303,7 +306,7 @@ export class DateTime {
     throw new Error('isSameOrAfter: Invalid unit!');
   }
 
-  public isSame(date, unit = 'seconds') {
+  public isSame(date: DateTime, unit = 'seconds'): boolean {
     switch (unit) {
       case 'second':
       case 'seconds':
@@ -323,7 +326,7 @@ export class DateTime {
     throw new Error('isSame: Invalid unit!');
   }
 
-  public add(duration, unit = 'seconds') {
+  public add(duration: number, unit = 'seconds'): DateTime {
     switch (unit) {
       case 'second':
       case 'seconds':
@@ -344,7 +347,7 @@ export class DateTime {
     return this;
   }
 
-  public subtract(duration, unit = 'seconds') {
+  public subtract(duration: number, unit = 'seconds'): DateTime {
     switch (unit) {
       case 'second':
       case 'seconds':
@@ -365,7 +368,7 @@ export class DateTime {
     return this;
   }
 
-  public diff(date, unit = 'seconds') {
+  public diff(date: DateTime, unit = 'seconds'): number {
     const oneDay = 1000 * 60 * 60 * 24;
 
     switch (unit) {
@@ -384,7 +387,7 @@ export class DateTime {
     }
   }
 
-  public format(format, lang = 'en-US') {
+  public format(format: string, lang: string = 'en-US'): string {
     let response = '';
     const match = format.match(/\[([^\]]+)]|Y{2,4}|M{1,4}|D{1,2}|d{1,4}/g);
 
@@ -449,7 +452,7 @@ export class DateTime {
     return response;
   }
 
-  private timestamp() {
+  private timestamp(): number {
     return new Date(this.getFullYear(), this.getMonth(), this.getDate(), 0, 0, 0, 0).getTime();
   }
 

--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -1,7 +1,7 @@
 import { Calendar } from './calendar';
 import { DateTime } from './datetime';
-import { findNestedMonthItem } from './utils';
 import * as style from './scss/main.scss';
+import { findNestedMonthItem } from './utils';
 
 export class Litepicker extends Calendar {
   protected triggerElement;
@@ -712,9 +712,9 @@ export class Litepicker extends Calendar {
   }
 
   private loadPolyfillsForIE11(): void {
-    // Support for Object.entries(...)
-    // copied from
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
+  // Support for Object.entries(...)
+  // copied from
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
     if (!Object.entries) {
       Object.entries = (obj) => {
         const ownProps = Object.keys(obj);
@@ -731,11 +731,13 @@ export class Litepicker extends Calendar {
     // copied from
     // https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
     if (!Element.prototype.matches) {
+      // tslint:disable-next-line: no-string-literal
       Element.prototype.matches = Element.prototype['msMatchesSelector'] ||
                                     Element.prototype.webkitMatchesSelector;
     }
     if (!Element.prototype.closest) {
       Element.prototype.closest = function (s) {
+        // tslint:disable-next-line: no-this-assignment
         let el = this;
 
         do {

--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -512,9 +512,8 @@ export class Litepicker extends Calendar {
     tooltip.style.visibility = 'hidden';
   }
 
-  private shouldAllowMouseEnter(el) {
+  private shouldAllowMouseEnter(el: HTMLElement) {
     return !this.options.singleMode
-      && el.classList.contains(style.dayItem)
       && !el.classList.contains(style.isLocked)
       && !el.classList.contains(style.isBooked);
   }
@@ -526,8 +525,20 @@ export class Litepicker extends Calendar {
       && this.options.endDate;
   }
 
+  private isDayItem(el: HTMLElement) {
+    return el.classList.contains(style.dayItem);
+  }
+
   private onMouseEnter(event) {
     const target = event.target as HTMLElement;
+    if (!this.isDayItem(target)) {
+      return;
+    }
+
+    if (typeof this.options.onDayHover === 'function') {
+      this.options.onDayHover.call(this, DateTime.parseDateTime(target.dataset.time),
+                                   target.classList.value?.split(/\s/));
+    }
 
     if (this.shouldAllowMouseEnter(target)) {
       if (this.shouldAllowRepick()) {

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -4,6 +4,7 @@ import * as style from './scss/main.scss';
 import { getOrientation, isMobile } from './utils';
 
 declare module './litepicker' {
+  // tslint:disable-next-line: interface-name
   interface Litepicker {
     show(element?);
     hide();

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -213,7 +213,6 @@
 
         &.is-locked {
           color: var(--litepickerDayIsLockedColor);
-          pointer-events: none;
 
           &:hover {
             color: var(--litepickerDayIsLockedColor);
@@ -224,7 +223,6 @@
 
         &.is-booked {
           color: var(--litepickerDayIsBookedColor);
-          pointer-events: none;
 
           &:hover {
             color: var(--litepickerDayIsBookedColor);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ export function getOrientation() {
 
 export function findNestedMonthItem(monthItem: Element): number {
   const children = monthItem.parentNode.childNodes;
-  for (let i = 0; i < children.length; i++) {
+  for (let i = 0; i < children.length; i = i + 1) {
     const curNode = children.item(i);
     if (curNode === monthItem) {
       return i;

--- a/tests/datetime.test.ts
+++ b/tests/datetime.test.ts
@@ -1,7 +1,7 @@
 import { DateTime } from '../src/datetime';
 
 // 23 Nov, 2019 - repository creation date
-const date = new Date(2019, 10, 23, 0, 0, 0, 0);
+const date = new DateTime(new Date(2019, 10, 23, 0, 0, 0, 0));
 
 test('new DateTime', () => {
   const dt1 = new DateTime();
@@ -29,6 +29,20 @@ test('DateTime.convertArray - lockDays/bookedDays', () => {
   ];
   const convertedArray = DateTime.convertArray(array, 'YYYY-MM-DD');
   convertedArray.forEach((dt) => {
+    if (dt instanceof Array) {
+      expect(dt[0] instanceof DateTime && !isNaN(dt[0].getTime())
+        && dt[1] instanceof DateTime && !isNaN(dt[1].getTime())).toBe(true);
+    } else {
+      expect(dt instanceof DateTime && !isNaN(dt.getTime())).toBe(true);
+    }
+  });
+  const array2 = [
+    new Date('2019-11-23'),
+    [new Date('2019-01-01'), new Date('2019-01-15')],
+    [new Date('2019-11-01'), new Date('2019-11-11')],
+  ];
+  const convertedArray2 = DateTime.convertArray(array2, 'YYYY-MM-DD');
+  convertedArray2.forEach((dt) => {
     if (dt instanceof Array) {
       expect(dt[0] instanceof DateTime && !isNaN(dt[0].getTime())
         && dt[1] instanceof DateTime && !isNaN(dt[1].getTime())).toBe(true);

--- a/tests/index-daterange.html
+++ b/tests/index-daterange.html
@@ -26,7 +26,12 @@
       allowRepick:true,
       singleMode:false,
       numberOfMonths: 2,
-    numberOfColumns: 2
+      numberOfColumns: 2,
+      maxDays:28,
+      minDays:1,
+      onDayHover: function(a,b) {
+        console.log(a,b);
+      }
     });
     document.getElementById("repick1").
     addEventListener("click", function() {

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,8 @@
     ],
     "jsRules": {},
     "rules": {
-        "no-console": false
+        "no-console": false,
+        "prefer-array-literal": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
This pull request primarily deals with a configurable event option named `onDayHover`. When configured, a custom function is called whenever a user of Litepicker hovers over / clicks on a day item. The function parameters are the Date object of the currently hovered / clicked day and an array with the day's css classes (e.g. `day-item`, `is-end-date`). 
What is this feature useful for? When embedded in a complex UI together with a a reactive framework like Vue.js, UI changes can be triggered with respect to the data this event transmits. In a way, where the information communicated by the tooltip is not sufficient, this feature can fill in the gap.