### PR TITLE
bugfix for #60 that prevented dates before 1970 to be selectable

### DIFF
--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -6,7 +6,7 @@ export class DateTime {
     if (date instanceof Date) return DateTime.getDateZeroTime(new Date(date));
     if (date instanceof DateTime) return date.clone().getDateInstance();
 
-    if (/^\d{10,}$/.test(date)) return DateTime.getDateZeroTime(new Date(Number(date)));
+    if (/^-?\d{10,}$/.test(date)) return DateTime.getDateZeroTime(new Date(Number(date)));
 
     if (typeof date === 'string') {
       const match = format.match(/\[([^\]]+)]|Y{2,4}|M{1,4}|D{1,2}|d{1,4}/g);


### PR DESCRIPTION
This hopefully fixes bug #60 that prevented dates before 1970 to be selectable. Basically, the bugfix encompasses only two characters. The problem was that the regexp in DateTime.parseDateTime() was not able to parse negative Unix epoch timestamps correctly. 