### PR TITLE
minor fix that improves IE11 support for the new onDayHover event

### DIFF
--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -557,7 +557,7 @@ export class Litepicker extends Calendar {
 
     if (typeof this.options.onDayHover === 'function') {
       this.options.onDayHover.call(this, DateTime.parseDateTime(target.dataset.time),
-        target.classList.value?.split(/\s/));
+                                   target.classList.toString().split(/\s/));
     }
 
     if (this.shouldAllowMouseEnter(target)) {


### PR DESCRIPTION
Unfortunately, `DomTokenList.value()` is not supported on IE11. However, `toString()` seems to do the same and works with in all relevant browser environments.