### PR TITLE
Fix JSON parse error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "node_modules",
     "**/node_modules/*",
     "src/methods.ts",
-    "tests",
+    "tests"
   ]
 }


### PR DESCRIPTION
Remove trailing comma to fix JSON parse error, as traditional JSON files don't support trailing commas.