### PR TITLE
Use mouseout event to reset date range to fix Firefox bug

### DIFF
--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -141,7 +141,7 @@ export class Litepicker extends Calendar {
     this.picker.className = style.litepicker;
     this.picker.style.display = 'none';
     this.picker.addEventListener('mouseenter', e => this.onMouseEnter(e), true);
-    this.picker.addEventListener('mouseleave', e => this.onMouseLeave(e), false);
+    this.picker.addEventListener('mouseout', e => this.onMouseOut(e), true);
 
     if (this.options.autoRefresh) {
       if (this.options.element instanceof HTMLElement) {
@@ -692,8 +692,11 @@ export class Litepicker extends Calendar {
     }
   }
 
-  private onMouseLeave(event) {
-    const target = event.target as any;
+  private onMouseOut(event) {
+    const target = event.target as HTMLElement;
+    if (target.className !== style.monthItem) {
+      return;
+    }
 
     if (!this.options.allowRepick
       || (this.options.allowRepick && !this.options.startDate && !this.options.endDate)) {
@@ -703,6 +706,7 @@ export class Litepicker extends Calendar {
     this.datePicked.length = 0;
     this.render();
   }
+
   private onInput(event) {
     let [startValue, endValue] = this.parseInput();
     let isValid = false;


### PR DESCRIPTION
Ref issue #138 

This PR fixes a problem in Firefox with the Month and Year select elements. Details of the problem are in the issue.

The issue is caused by Firefox firing the `mouseleave` event when the mouse is moved off of the Month/Year select element. This causes the event handler to reset the `datePicked` array length to `0` and render the component, causing the options list to disappear.

The change is to use the `mouseout`  event instead of `mouseleave`. and in the event handler check the `className` attribute of the event target. If the class name of the target is not `style.monthItem`, the class applied to the outer month container, the event is ignored.