### PR TITLE
Add static, left and top properties

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -31,6 +31,9 @@ export class LPCore extends EventEmitter {
     endDate: null,
     zIndex: 9999,
     position: 'auto',
+    static: false,
+    left: null,
+    top: null,
 
     selectForward: false,
     selectBackward: false,
@@ -265,6 +268,12 @@ export class LPCore extends EventEmitter {
   }
 
   protected findPosition(element) {
+    const isStatic = this.options.static || false;
+
+    if (isStatic) {
+        return { left: this.options.left || 0, top: this.options.top || 0 };
+    }
+
     const rect = element.getBoundingClientRect();
     const calRect = this.ui.getBoundingClientRect();
     const orientation = this.options.position.split(' ');

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -70,6 +70,9 @@ export interface ILPConfiguration {
   tooltipNumber?: (totalDays: number) => number;
   plugins?: string[];
   position?: string;
+  static?: boolean;
+  left?: number | null;
+  top?: number | null;
 
   // Plugins
   ranges?: {


### PR DESCRIPTION
Hey @wakirin 

We have a production SPA app and all screens are actually modals. With that, date picker always showing itself on wrong position.

![image](https://user-images.githubusercontent.com/2091777/112622300-ea4c0f80-8e3b-11eb-976d-4513cc02d420.png)

I believe this and next line is the reason for that. https://github.com/wakirin/Litepicker/blob/2336ce1b0ac3a4ef733fda0eef8b9ef4dd99b0d0/src/core.ts#L271

There is no offset. It returns always 0. Just inline mode works as expected.

We researched the other date pickers and we saw the results someting similar.

![image](https://user-images.githubusercontent.com/2091777/112622457-1b2c4480-8e3c-11eb-86c9-c1c14c43aa07.png)

But `flatpickr` giving us an option to resolve this issue with named `static`. Here: https://github.com/flatpickr/flatpickr/blob/31d0195b0cb8261685a3ec9093341bc54675fb09/src/index.ts#L2188

This option allows us to place datepicker statically next to element. This PR targets the same result.

Thank you.