### PR TITLE
Disallow selecting days when range is locked

### DIFF
--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -373,6 +373,9 @@ export class Litepicker extends Calendar {
         date2 = tempDate.clone();
         isFlipped = true;
       }
+      if (this.shouldCheckLockDays() && rangeIsLocked([date1, date2], this.options)) {
+        return;
+      }
       const allDayItems = Array.prototype.slice.call(this.ui.querySelectorAll(`.${style.dayItem}`));
       allDayItems.forEach((d: HTMLElement) => {
         const date = new DateTime(d.dataset.time);


### PR DESCRIPTION
When you use `disallowLockDaysInRange` and hover over a range that has locked days in it, the range is selected regardless.
Only when the user clicks on the second date the selection disappears, because there were locked days in the range.
This is confusing for the user. It should not be possible to select a range with locked days during the selection process.