### PR TITLE
Shadow root support

### DIFF
--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -151,7 +151,11 @@ export class Litepicker extends Calendar {
   }
 
   private onClick(e) {
-    const target = e.target as HTMLElement;
+    let target = e.target as HTMLElement;
+
+    if (e.target.shadowRoot) {
+      target = e.composedPath()[0] as HTMLElement;
+    }
 
     if (!target || !this.ui) {
       return;


### PR DESCRIPTION
The onclick event is listened to on "document", when the datepicker is added to a shadowDOM element though, the event target would be the shadowDOM and not the datepicker.

By checking for shadowRoot and using composedPath(), everything works as expected.