### PR TITLE
Support custom labels for ranges

### DIFF
--- a/src/plugins/ranges/index.js
+++ b/src/plugins/ranges/index.js
@@ -5,14 +5,11 @@ Litepicker.add('ranges', {
     const defaultOptions = {
       position: 'left',
       customRanges: {},
+      customRangesLabels: ['Today', 'Yesterday', 'Last 7 Days', 'Last 30 Days', 'This Month', 'Last Month'],
       force: false,
       autoApply: picker.options.autoApply,
     };
     picker.options.ranges = { ...defaultOptions, ...picker.options.ranges };
-
-    if (picker.options.ranges.customRangesLabels === undefined) {
-      picker.options.ranges.customRangesLabels = ['Today', 'Yesterday', 'Last 7 Days', 'Last 30 Days', 'This Month', 'Last Month'];
-    }
 
     picker.options.singleMode = false;
 

--- a/src/plugins/ranges/index.js
+++ b/src/plugins/ranges/index.js
@@ -10,9 +10,15 @@ Litepicker.add('ranges', {
     };
     picker.options.ranges = { ...defaultOptions, ...picker.options.ranges };
 
+    if (picker.options.ranges.customRangesLabels === undefined) {
+      picker.options.ranges.customRangesLabels = ['Today', 'Yesterday', 'Last 7 Days', 'Last 30 Days', 'This Month', 'Last Month'];
+    }
+
     picker.options.singleMode = false;
 
-    if (!Object.keys(picker.options.ranges.customRanges).length) {
+    const options = picker.options.ranges;
+
+    if (!Object.keys(options.customRanges).length) {
       const date = picker.DateTime();
 
       const thisMonth = (date) => {
@@ -32,17 +38,15 @@ Litepicker.add('ranges', {
         return [d1, d2];
       };
 
-      picker.options.ranges.customRanges = {
-        Today: [date.clone(), date.clone()],
-        Yesterday: [date.clone().subtract(1, 'day'), date.clone().subtract(1, 'day')],
-        'Last 7 Days': [date.clone().subtract(6, 'day'), date],
-        'Last 30 Days': [date.clone().subtract(29, 'day'), date],
-        'This Month': thisMonth(date),
-        'Last Month': lastMonth(date),
+      options.customRanges = {
+        [options.customRangesLabels[0]]: [date.clone(), date.clone()],
+        [options.customRangesLabels[1]]: [date.clone().subtract(1, 'day'), date.clone().subtract(1, 'day')],
+        [options.customRangesLabels[2]]: [date.clone().subtract(6, 'day'), date],
+        [options.customRangesLabels[3]]: [date.clone().subtract(29, 'day'), date],
+        [options.customRangesLabels[4]]: thisMonth(date),
+        [options.customRangesLabels[5]]: lastMonth(date),
       };
     }
-
-    const options = picker.options.ranges;
 
     picker.on('render', (ui) => {
       const block = document.createElement('div');


### PR DESCRIPTION
Proposed fix to add support for customizing labels for ranges plugin. 
- Fix  #223 & #230

It allows to pass a new **customRangesLabels** parameter to config at init. For example, for French:

```js
ranges: {
    customRangesLabels: ['Aujourd\'hui', 'Hier', 'Les 7 derniers jours', 'Les 30 derniers jours', 'Ce mois-ci', 'Le mois dernier']
}
```

I don't know if the proposal is good, I've done that in a few minutes to solve the problem in my project.
Any better solution is welcomed :)