### PR TITLE
fixes wrong element update

### DIFF
--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -335,7 +335,8 @@ export class Litepicker extends Calendar {
     return this.options.elementEnd
       && this.options.allowRepick
       && this.options.startDate
-      && this.options.endDate;
+      && this.options.endDate
+      && this.datePicked.length < 2;
   }
 
   private isDayItem(el: HTMLElement) {


### PR DESCRIPTION
mouseenter is fired after `Click on date` which leads to wrong variable update when allowRepick is enabled.
With this fix repicking is only possible if it's first repicking after trigger element was clicked.

Fixes #258 
