### PR TITLE
add option showOnClick default true

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -39,6 +39,7 @@ export class LPCore extends EventEmitter {
     singleMode: true,
     autoApply: true,
     allowRepick: false,
+    showOnClick: true,
     showWeekNumbers: false,
     showTooltip: true,
     scrollToDate: true,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -47,6 +47,7 @@ export interface ILPConfiguration {
   singleMode?: boolean;
   autoApply?: boolean;
   allowRepick?: boolean;
+  showOnClick?: boolean;
   showWeekNumbers?: boolean;
   showTooltip?: boolean;
   scrollToDate?: boolean;

--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -132,7 +132,7 @@ export class Litepicker extends Calendar {
   }
 
   private shouldShown(el) {
-    return !el.disabled && (el === this.options.element
+    return !el.disabled && this.options.showOnClick && (el === this.options.element
       || (this.options.elementEnd && el === this.options.elementEnd));
   }
 


### PR DESCRIPTION
adds a new option showOnClick which defaults to `true` to keep current default behaviours. when set to `false` the popup will not be triggered by clicking on the input field, only by calls to the `.show()` method. The second half needed to solve #267 cleanly.